### PR TITLE
Reset ingredients innerHTML with each modal population

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -180,6 +180,7 @@ const populateBigModal = (event) => {
   selectedRecipe.instructions.forEach((instruction, i) => {
     bigModalInstructions.innerHTML += `<li class="med-top-marg med-font">${selectedRecipe.getInstructions()[i]}</li>`;
   });
+  bigModalIngredients.innerHTML = ''
   selectedRecipe.ingredients.forEach((ingredient, i) => {
     bigModalIngredients.innerHTML += `<li class="flex align-start med-left-marg med-top-marg med-font">${selectedRecipe.getIngredientNames(ingredients)[i]}</li>`;
   });


### PR DESCRIPTION
## What Features are Being Added?
None


## What is Being Refactored?
Updating the populateBigModal function so that it resets the innerhtml to an empty string first, ensuring that the ingredient list is unique to each recipe, and not an ever expanding list


## What Do You Need From Your Teammates?
Just take a look at the functionality and make sure it works ok!


## Any Other Notes/Questions/Problems?
None at this time!